### PR TITLE
Fixed reading ReSentences with empty value

### DIFF
--- a/tik4net/Api/ApiSentence.cs
+++ b/tik4net/Api/ApiSentence.cs
@@ -22,7 +22,7 @@ namespace tik4net.Api
 
         public ApiSentence(IEnumerable<string> words)
         {
-            Regex keyValueRegex = new Regex("^=?(?<KEY>[^=]+)=(?<VALUE>.+)$", RegexOptions.Singleline);
+            Regex keyValueRegex = new Regex("^=?(?<KEY>[^=]+)=(?<VALUE>.*)$", RegexOptions.Singleline);
             foreach(string word in words)
             {
                 Match match = keyValueRegex.Match(word);


### PR DESCRIPTION
Changed RegEx to allow for sentences with empty values. Fixes #97