### PR TITLE
Update to handle the new RouterOS v7.18 api syntax with empty responses

### DIFF
--- a/tik4net/Api/ApiCommand.cs
+++ b/tik4net/Api/ApiCommand.cs
@@ -403,6 +403,8 @@ namespace tik4net.Api
                 EnsureReReponse(response.Take(response.Count() - 1).ToArray());   //!re  - reapeating 
                 EnsureDoneResponse(response.Last()); //!done
 
+                if (response.First() is ApiEmptySentence)
+                    return new List<ITikReSentence>();
                 return response.Take(response.Count() - 1).Cast<ITikReSentence>().ToList();
             }
             finally

--- a/tik4net/Api/ApiConnection.cs
+++ b/tik4net/Api/ApiConnection.cs
@@ -354,6 +354,7 @@ namespace tik4net.Api
                     case "!trap": return new ApiTrapSentence(sentenceWords);
                     case "!re": return new ApiReSentence(sentenceWords);
                     case "!fatal": return new ApiFatalSentence(sentenceWords);
+                    case "!empty": return new ApiEmptySentence();
                     case "": throw new IOException("Can not read sentence from connection"); // With SSL possibly not logged in  (SSL and new router with SSL_V2)
                     default: throw new NotImplementedException(string.Format("Response type '{0}' not supported", sentenceName));
                 }

--- a/tik4net/Api/ApiEmptySentence.cs
+++ b/tik4net/Api/ApiEmptySentence.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace tik4net.Api
+{
+    internal class ApiEmptySentence : ApiReSentence, ITikDoneSentence
+    {
+        public ApiEmptySentence() 
+            : base(Array.Empty<string>())
+        {
+        }
+
+        public string GetResponseWord()
+        {
+            return GetWordValue(TikSpecialProperties.Ret);
+        }
+
+        public string GetResponseWordOrDefault(string defaultValue)
+        {
+            return GetWordValueOrDefault(TikSpecialProperties.Ret, defaultValue);
+        }
+    }
+}


### PR DESCRIPTION
- Added handling for `ApiEmptySentence` in `ApiCommand.cs` to return an empty list when the first response is empty.
- Introduced `!empty` case in `ApiConnection.cs` to process empty responses.
- Created `ApiEmptySentence` class to manage empty response types, enhancing API functionality.