### PR TITLE
Add User Manager objects and tests

### DIFF
--- a/tik4net.objects/UserManager/UserManagerLimitation.cs
+++ b/tik4net.objects/UserManager/UserManagerLimitation.cs
@@ -1,0 +1,71 @@
+﻿namespace tik4net.Objects.UserManager
+{
+    [TikEntity("/user-manager/limitation", IncludeDetails = true)]
+    public class UserManagerLimitation
+    {
+        /// <summary>
+        /// .id: primary key of row
+        /// </summary>
+        [TikProperty(".id", IsReadOnly = true, IsMandatory = true)]
+        public string Id { get; private set; }
+
+        [TikProperty("comment")]
+        public string Comment { get; set; }
+
+        [TikProperty("download-limit")]
+        public int DownloadLimit { get; set; }
+
+        [TikProperty("name", IsMandatory = true)]
+        public string Name { get; set; }
+
+        [TikProperty("rate-limit-burst-rx")]
+        public string RateLimitBurstRx { get; set; }
+
+        [TikProperty("rate-limit-burst-threshold-rx")]
+        public string RateLimitBurstThresholdRx { get; set; }
+
+        [TikProperty("rate-limit-burst-threshold-tx")]
+        public string RateLimitBurstThresholdTx { get; set; }
+
+        [TikProperty("rate-limit-burst-time-rx")]
+        public string RateLimitBurstTimeRx { get; set; }
+
+        [TikProperty("rate-limit-burst-time-tx")]
+        public string RateLimitBurstTimeTx { get; set; }
+
+        [TikProperty("rate-limit-burst-tx")]
+        public string RateLimitBurstTx { get; set; }
+
+        [TikProperty("rate-limit-min-rx")]
+        public string RateLimitMinRx { get; set; }
+
+        [TikProperty("rate-limit-min-tx")]
+        public string RateLimitMinTx { get; set; }
+
+        [TikProperty("rate-limit-priority")]
+        public string RateLimitPriority { get; set; }
+
+        [TikProperty("rate-limit-rx")]
+        public string RateLimitRx { get; set; }
+
+        [TikProperty("rate-limit-tx")]
+        public string RateLimitTx { get; set; }
+
+        [TikProperty("reset-counters-interval", DefaultValue = "disabled")]
+        public string/* hourly|daily|weekly|monthly|disabled*/ ResetCounterInterval { get; set; }
+
+        [TikProperty("reset-counters-start-time")]
+        public string ResetCountersStartTime { get; set; }
+
+        [TikProperty("transfer-limit")]
+        public int TransferLimit { get; set; }
+
+        [TikProperty("upload-limit")]
+        public int UploadLimit { get; set; }
+
+        [TikProperty("uptime-limit", DefaultValue = "00:00:00")]
+        public string UptimeLimit { get; set; }
+
+
+    }
+}

--- a/tik4net.objects/UserManager/UserManagerProfile.cs
+++ b/tik4net.objects/UserManager/UserManagerProfile.cs
@@ -1,6 +1,6 @@
 ﻿namespace tik4net.Objects.UserManager
 {
-    [TikEntity("/user-manager/profile")]
+    [TikEntity("/user-manager/profile", IncludeDetails = true)]
     public class UserManagerProfile
     {
         /// <summary>
@@ -9,25 +9,33 @@
         [TikProperty(".id", IsReadOnly = true, IsMandatory = true)]
         public string Id { get; private set; }
 
-        [TikProperty("comment", DefaultValue = "")]
+        [TikProperty("comment")]
         public string Comment { get; set; }
 
-        [TikProperty("name", DefaultValue = "")]
+        [TikProperty("name", IsMandatory = true)]
         public string Name { get; set; }
 
-        [TikProperty("name-for-users", DefaultValue = "")]
+        [TikProperty("name-for-users")]
         public string NameForUsers { get; set; }
 
-        [TikProperty("override-shared-users", DefaultValue = "off")]
+        [TikProperty("override-shared-users", DefaultValue = "off", IsMandatory = true)]
         public string/*decimal | off | unlimited*/ OverrideSharedUsers { get; set; }
 
-        [TikProperty("price", DefaultValue = "0")]
-        public decimal Price { get; set; }
+        [TikProperty("price", DefaultValue = "0", IsMandatory = true)]
+        public string Price { get; set; }
 
-        [TikProperty("starts-when", DefaultValue = "assigned")]
+        [TikProperty("starts-when", DefaultValue = "assigned", IsMandatory = true)]
         public string/*assigned | first-auth*/ StartsWhen { get; set; }
 
-        [TikProperty("validity", DefaultValue = "unlimited")]
+        [TikProperty("validity")] //, DefaultValue = "unlimited", IsMandatory = true)]
         public string/*time | unlimited*/ Validity { get; set; }
+
+        public UserManagerProfile()
+        {
+            OverrideSharedUsers = "off";
+            Price = "0";
+            StartsWhen = "assigned";
+            Validity = "unlimited";
+        }
     }
 }

--- a/tik4net.objects/UserManager/UserManagerProfile.cs
+++ b/tik4net.objects/UserManager/UserManagerProfile.cs
@@ -1,0 +1,33 @@
+﻿namespace tik4net.Objects.UserManager
+{
+    [TikEntity("/user-manager/profile")]
+    public class UserManagerProfile
+    {
+        /// <summary>
+        /// .id: primary key of row
+        /// </summary>
+        [TikProperty(".id", IsReadOnly = true, IsMandatory = true)]
+        public string Id { get; private set; }
+
+        [TikProperty("comment", DefaultValue = "")]
+        public string Comment { get; set; }
+
+        [TikProperty("name", DefaultValue = "")]
+        public string Name { get; set; }
+
+        [TikProperty("name-for-users", DefaultValue = "")]
+        public string NameForUsers { get; set; }
+
+        [TikProperty("override-shared-users", DefaultValue = "off")]
+        public string/*decimal | off | unlimited*/ OverrideSharedUsers { get; set; }
+
+        [TikProperty("price", DefaultValue = "0")]
+        public decimal Price { get; set; }
+
+        [TikProperty("starts-when", DefaultValue = "assigned")]
+        public string/*assigned | first-auth*/ StartsWhen { get; set; }
+
+        [TikProperty("validity", DefaultValue = "unlimited")]
+        public string/*time | unlimited*/ Validity { get; set; }
+    }
+}

--- a/tik4net.objects/UserManager/UserManagerProfileLimitation.cs
+++ b/tik4net.objects/UserManager/UserManagerProfileLimitation.cs
@@ -1,0 +1,30 @@
+﻿namespace tik4net.Objects.UserManager
+{
+    [TikEntity("/user-manager/profile-limitation")]
+    public class UserManagerProfileLimitation
+    {
+        /// <summary>
+        /// .id: primary key of row
+        /// </summary>
+        [TikProperty(".id", IsReadOnly = true, IsMandatory = true)]
+        public string Id { get; private set; }
+
+        [TikProperty("comment", DefaultValue = "")]
+        public string Comment { get; set; }
+
+        [TikProperty("from-time", DefaultValue = "00:00:00")]
+        public string FromTime { get; set; }
+
+        [TikProperty("limitation ", DefaultValue = "")]
+        public string Limitation { get; set; }
+
+        [TikProperty("profile ", DefaultValue = "")]
+        public string Profile { get; set; }
+
+        [TikProperty("till-time", DefaultValue = "23:59:59")]
+        public decimal TillTime { get; set; }
+
+        [TikProperty("weekdays", DefaultValue = "Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday")]
+        public string/*day of week*/ Weekdays { get; set; }
+    }
+}

--- a/tik4net.objects/UserManager/UserManagerProfileLimitation.cs
+++ b/tik4net.objects/UserManager/UserManagerProfileLimitation.cs
@@ -1,6 +1,6 @@
 ﻿namespace tik4net.Objects.UserManager
 {
-    [TikEntity("/user-manager/profile-limitation")]
+    [TikEntity("/user-manager/profile-limitation", IncludeDetails = true)]
     public class UserManagerProfileLimitation
     {
         /// <summary>
@@ -9,22 +9,22 @@
         [TikProperty(".id", IsReadOnly = true, IsMandatory = true)]
         public string Id { get; private set; }
 
-        [TikProperty("comment", DefaultValue = "")]
+        [TikProperty("comment")]
         public string Comment { get; set; }
 
         [TikProperty("from-time", DefaultValue = "00:00:00")]
         public string FromTime { get; set; }
 
-        [TikProperty("limitation ", DefaultValue = "")]
+        [TikProperty("limitation")]
         public string Limitation { get; set; }
 
-        [TikProperty("profile ", DefaultValue = "")]
+        [TikProperty("profile")]
         public string Profile { get; set; }
 
         [TikProperty("till-time", DefaultValue = "23:59:59")]
-        public decimal TillTime { get; set; }
+        public string TillTime { get; set; }
 
-        [TikProperty("weekdays", DefaultValue = "Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday")]
+        [TikProperty("weekdays", DefaultValue = "sunday,monday,tuesday,wednesday,thursday,friday,saturday")]
         public string/*day of week*/ Weekdays { get; set; }
     }
 }

--- a/tik4net.objects/UserManager/UserManagerUser.cs
+++ b/tik4net.objects/UserManager/UserManagerUser.cs
@@ -1,0 +1,40 @@
+﻿namespace tik4net.Objects.UserManager
+{
+    [TikEntity("/user-manager/user")]
+    public class UserManagerUser
+    {
+        /// <summary>
+        /// .id: primary key of row
+        /// </summary>
+        [TikProperty(".id", IsReadOnly = true, IsMandatory = true)]
+        public string Id { get; private set; }
+
+        [TikProperty("attributes")]
+        public string/* array of attributes */ Attributes { get; set; }
+
+        [TikProperty("caller-id")]
+        public string CallerId { get; set; }
+
+        [TikProperty("disabled")]
+        public bool Disabled { get; set; }
+
+        [TikProperty("comment")]
+        public string Comment { get; set; }
+
+        [TikProperty("group", DefaultValue = "default")]
+        public string Group { get; set; }
+
+        [TikProperty("name", IsMandatory = true)]
+        public string Name { get; set; }
+
+        [TikProperty("otp-secret")]
+        public string OTPSecret { get; set; }
+
+        [TikProperty("password")]
+        public string Password { get; set; }
+
+        [TikProperty("shared-users ", DefaultValue = "1")]
+        public string/*integer | unlimited*/ SharedUsers { get; set; }
+
+    }
+}

--- a/tik4net.objects/UserManager/UserManagerUser.cs
+++ b/tik4net.objects/UserManager/UserManagerUser.cs
@@ -1,6 +1,6 @@
 ﻿namespace tik4net.Objects.UserManager
 {
-    [TikEntity("/user-manager/user")]
+    [TikEntity("/user-manager/user", IncludeDetails = true)]
     public class UserManagerUser
     {
         /// <summary>

--- a/tik4net.objects/UserManager/UserManagerUser.cs
+++ b/tik4net.objects/UserManager/UserManagerUser.cs
@@ -33,7 +33,7 @@
         [TikProperty("password")]
         public string Password { get; set; }
 
-        [TikProperty("shared-users ", DefaultValue = "1")]
+        [TikProperty("shared-users", DefaultValue = "1")]
         public string/*integer | unlimited*/ SharedUsers { get; set; }
 
     }

--- a/tik4net.objects/UserManager/UserManagerUserGroup.cs
+++ b/tik4net.objects/UserManager/UserManagerUserGroup.cs
@@ -1,6 +1,6 @@
 ﻿namespace tik4net.Objects.UserManager
 {
-    [TikEntity("/user-manager/user/group")]
+    [TikEntity("/user-manager/user/group", IncludeDetails = true)]
     public class UserManagerUserGroup
     {
         /// <summary>
@@ -9,19 +9,19 @@
         [TikProperty(".id", IsReadOnly = true, IsMandatory = true)]
         public string Id { get; private set; }
 
-        [TikProperty("attributes", DefaultValue = "")]
+        [TikProperty("attributes")]
         public string/* array of attributes */ Attributes { get; set; }
 
-        [TikProperty("comment", DefaultValue = "")]
+        [TikProperty("comment")]
         public string Comment { get; set; }
 
-        [TikProperty("name", DefaultValue = "")]
+        [TikProperty("name", IsMandatory = true)]
         public string Name { get; set; }
 
-        [TikProperty("inner-auths", DefaultValue = "")]
+        [TikProperty("inner-auths")]
         public string/* list of auths*/ InnerAuths { get; set; }
 
-        [TikProperty("outer-auths", DefaultValue = "")]
-        public string/* list of auths*/ Password { get; set; }
+        [TikProperty("outer-auths")]
+        public string/* list of auths*/ OuterAuths { get; set; }
     }
 }

--- a/tik4net.objects/UserManager/UserManagerUserGroup.cs
+++ b/tik4net.objects/UserManager/UserManagerUserGroup.cs
@@ -1,0 +1,27 @@
+﻿namespace tik4net.Objects.UserManager
+{
+    [TikEntity("/user-manager/user/group")]
+    public class UserManagerUserGroup
+    {
+        /// <summary>
+        /// .id: primary key of row
+        /// </summary>
+        [TikProperty(".id", IsReadOnly = true, IsMandatory = true)]
+        public string Id { get; private set; }
+
+        [TikProperty("attributes", DefaultValue = "")]
+        public string/* array of attributes */ Attributes { get; set; }
+
+        [TikProperty("comment", DefaultValue = "")]
+        public string Comment { get; set; }
+
+        [TikProperty("name", DefaultValue = "")]
+        public string Name { get; set; }
+
+        [TikProperty("inner-auths", DefaultValue = "")]
+        public string/* list of auths*/ InnerAuths { get; set; }
+
+        [TikProperty("outer-auths", DefaultValue = "")]
+        public string/* list of auths*/ Password { get; set; }
+    }
+}

--- a/tik4net.objects/UserManager/UserManagerUserProfile.cs
+++ b/tik4net.objects/UserManager/UserManagerUserProfile.cs
@@ -1,0 +1,25 @@
+﻿namespace tik4net.Objects.UserManager
+{
+    [TikEntity("/user-manager/user-profile", IncludeDetails = true)]
+    public class UserManagerUserProfile
+    {
+        /// <summary>
+        /// .id: primary key of row
+        /// </summary>
+        [TikProperty(".id", IsReadOnly = true, IsMandatory = true)]
+        public string Id { get; private set; }
+
+        [TikProperty("profile", IsMandatory = true)]
+        public string Profile { get; set; }
+
+        [TikProperty("user", IsMandatory = true)]
+        public string User { get; set; }
+
+        [TikProperty("state", IsReadOnly = true)]
+        public string State { get; private set; }
+
+        [TikProperty("end-time", IsReadOnly = true)]
+        public string EndTime { get; private set; }
+
+    }
+}

--- a/tik4net.objects/tik4net.objects.csproj
+++ b/tik4net.objects/tik4net.objects.csproj
@@ -12,7 +12,7 @@
      <Copyright>Copyright (C) Daniel Frantik 2017</Copyright>
      <PackageTags>Mikrotik</PackageTags>
      <PackageOutputPath>../Build</PackageOutputPath>
-     <VersionPrefix>3.0.0</VersionPrefix>
+     <VersionPrefix>3.5.2</VersionPrefix>
      <VersionSuffix Condition=" '$(BUILD_BUILDNUMBER)' != '' ">CI-$(BUILD_BUILDNUMBER)</VersionSuffix>
      <VersionSuffix Condition=" '$(PREVIEW_NUMBER)' != '' ">pre-$(PREVIEW_NUMBER)</VersionSuffix>
      <AssemblyName>tik4net.objects</AssemblyName>

--- a/tik4net.sln
+++ b/tik4net.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26403.3
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36603.0 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tik4net", "tik4net\tik4net.csproj", "{15288F76-5A85-418E-87B2-B22265726601}"
 EndProject
@@ -23,6 +23,12 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tik4net.tests", "tik4net.tests\tik4net.tests.csproj", "{2FB8E75F-9F49-4A8A-BC57-7CD299807EEE}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tik4net.coreconsole", "tik4net.coreconsole\tik4net.coreconsole.csproj", "{98A3B7AB-1D5C-49B5-AD91-7BA87F876D98}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tik4net.entitygenerator", "Tools\tik4net.entitygenerator\tik4net.entitygenerator.csproj", "{85F6F563-8858-4626-8AFD-C6F6B245914C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tik4net.entityWikiImporter", "Tools\tik4net.entityWikiImporter\tik4net.entityWikiImporter.csproj", "{082F22E7-4DF1-4423-9D65-FD4CE9157FAD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -88,6 +94,22 @@ Global
 		{98A3B7AB-1D5C-49B5-AD91-7BA87F876D98}.Release|Any CPU.Build.0 = Release|Any CPU
 		{98A3B7AB-1D5C-49B5-AD91-7BA87F876D98}.Release|x86.ActiveCfg = Release|Any CPU
 		{98A3B7AB-1D5C-49B5-AD91-7BA87F876D98}.Release|x86.Build.0 = Release|Any CPU
+		{85F6F563-8858-4626-8AFD-C6F6B245914C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{85F6F563-8858-4626-8AFD-C6F6B245914C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{85F6F563-8858-4626-8AFD-C6F6B245914C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{85F6F563-8858-4626-8AFD-C6F6B245914C}.Debug|x86.Build.0 = Debug|Any CPU
+		{85F6F563-8858-4626-8AFD-C6F6B245914C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{85F6F563-8858-4626-8AFD-C6F6B245914C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{85F6F563-8858-4626-8AFD-C6F6B245914C}.Release|x86.ActiveCfg = Release|Any CPU
+		{85F6F563-8858-4626-8AFD-C6F6B245914C}.Release|x86.Build.0 = Release|Any CPU
+		{082F22E7-4DF1-4423-9D65-FD4CE9157FAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{082F22E7-4DF1-4423-9D65-FD4CE9157FAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{082F22E7-4DF1-4423-9D65-FD4CE9157FAD}.Debug|x86.ActiveCfg = Debug|x86
+		{082F22E7-4DF1-4423-9D65-FD4CE9157FAD}.Debug|x86.Build.0 = Debug|x86
+		{082F22E7-4DF1-4423-9D65-FD4CE9157FAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{082F22E7-4DF1-4423-9D65-FD4CE9157FAD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{082F22E7-4DF1-4423-9D65-FD4CE9157FAD}.Release|x86.ActiveCfg = Release|x86
+		{082F22E7-4DF1-4423-9D65-FD4CE9157FAD}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -98,5 +120,7 @@ Global
 		{AE25F73D-7CE5-4C14-8AAC-1A32ECC38DA5} = {0436FBF0-DA39-41EC-B052-255BCA0DC913}
 		{2FB8E75F-9F49-4A8A-BC57-7CD299807EEE} = {0436FBF0-DA39-41EC-B052-255BCA0DC913}
 		{98A3B7AB-1D5C-49B5-AD91-7BA87F876D98} = {0436FBF0-DA39-41EC-B052-255BCA0DC913}
+		{85F6F563-8858-4626-8AFD-C6F6B245914C} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{082F22E7-4DF1-4423-9D65-FD4CE9157FAD} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 EndGlobal

--- a/tik4net.tests/App.config
+++ b/tik4net.tests/App.config
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="host" value="192.168.100.1"/>
-    <add key="user" value="admin"/>
-    <add key="pass" value="Kx7y3110771"/>
+	  <add key="host" value="192.168.3.117"/>
+	  <add key="user" value="admin"/>
+	  <add key="pass" value=""/>
   </appSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/tik4net.tests/App.config
+++ b/tik4net.tests/App.config
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="host" value="192.168.4.236"/>
+    <add key="host" value="192.168.100.1"/>
     <add key="user" value="admin"/>
-    <add key="pass" value=""/>
+    <add key="pass" value="Kx7y3110771"/>
   </appSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/tik4net.tests/IpHotspotTest.cs
+++ b/tik4net.tests/IpHotspotTest.cs
@@ -1,15 +1,13 @@
 ﻿using System;
-using System.Configuration;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using tik4net.Objects.Ip.Hotspot;
 using tik4net.Objects;
-using System.Collections.Generic;
+using tik4net.Objects.Ip.Hotspot;
 
 namespace tik4net.tests
 {
     [TestClass]
-    public class IpHotspotTest: TestBase
+    public class IpHotspotTest : TestBase
     {
         #region HotspotActive
         [TestMethod]
@@ -33,9 +31,11 @@ namespace tik4net.tests
         [TestMethod]
         public void AddSingleUserWillNotFail()
         {
+            var rnd = new Random();
+            //Create user
             var user = new HotspotUser()
             {
-                Name = "TEST " + DateTime.Now.ToString(),
+                Name = $"TEST{rnd.Next(999)}",
                 LimitUptime = "1:00:00",
                 Password = "secretpass",
             };
@@ -46,10 +46,11 @@ namespace tik4net.tests
         [TestMethod]
         public void UpdateUserWillNotFail()
         {
+            var rnd = new Random();
             //Create user
             var user = new HotspotUser()
             {
-                Name = "TEST " + DateTime.Now.ToString(),
+                Name = $"TEST{rnd.Next(999)}",
                 LimitUptime = "1:00:00",
                 Password = "secretpass",
             };
@@ -98,7 +99,7 @@ namespace tik4net.tests
         public void DeleteAllUserProfilesWillNotFail()
         {
             var list = Connection.LoadAll<HotspotUserProfile>();
-            Connection.SaveListDifferences(list.Where(l=>l.Name == "default") /*list with "default" as expected => delete all others*/, list);
+            Connection.SaveListDifferences(list.Where(l => l.Name == "default") /*list with "default" as expected => delete all others*/, list);
         }
         #endregion
 
@@ -117,7 +118,7 @@ namespace tik4net.tests
             {
                 Address = ADDRESS,
             };
-            
+
             Connection.Save(binding);
             var loadedBinding = Connection.LoadAll<HotspotIpBinding>().SingleOrDefault(ib => ib.Address == ADDRESS);
             Assert.IsNotNull(loadedBinding);
@@ -127,4 +128,5 @@ namespace tik4net.tests
 
         #endregion
     }
+
 }

--- a/tik4net.tests/UserManagerTest.cs
+++ b/tik4net.tests/UserManagerTest.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using tik4net.Objects;
+using tik4net.Objects.UserManager;
+
+namespace tik4net.tests
+{
+    [TestClass]
+    public class UserManagerTest : TestBase
+    {
+        #region UserManagerUserGroups
+        [TestMethod]
+        public void ListAllUserWillNotFail()
+        {
+            var list = Connection.LoadAll<UserManagerUserGroup>().ToList();
+        }
+
+
+        #endregion
+
+        #region UserManagerUsers
+        [TestMethod]
+        public void AddSingleUserWillNotFail()
+        {
+            var rnd = new Random();
+            var user = new UserManagerUser()
+            {
+                Name = $"TEST{rnd.Next(999)}",
+                Password = "secretpass",
+                Group = "default",
+            };
+
+            Connection.Save(user);
+        }
+
+        [TestMethod]
+        public void UpdateUserWillNotFail()
+        {
+            var rnd = new Random();
+
+            //Create user
+            var user = new UserManagerUser()
+            {
+                Name = $"TEST{rnd.Next(999)}",
+                Group = "default",
+                Password = "secretpass",
+            };
+            Connection.Save(user);
+
+            //Update
+            user.Password = "changed";
+            Connection.Save(user);
+
+            //Cleanup
+            Connection.Delete(user);
+        }
+
+        [Ignore] //DAF: potentionaly harmfull test
+        [TestMethod]
+        public void DeleteAllUsersWillNotFail()
+        {
+            var users = Connection.DeleteAll<UserManagerUser>();
+        }
+
+        [TestMethod]
+        public void AddUserWithGroupWillNotFail()
+        {
+            var rnd = new Random();
+
+            string groupName = $"TEST{rnd.Next(999)}";
+            var userGroup = new UserManagerUserGroup()
+            {
+                Name = groupName
+            };
+            Connection.Save(userGroup);
+
+            var user = new UserManagerUser()
+            {
+                Name = "User for " + groupName,
+                Group = groupName,
+            };
+            Connection.Save(user);
+
+            //cleanup
+            Connection.Delete(user);
+            Connection.Delete(userGroup);
+        }
+
+        [Ignore] //DAF: potentionaly harmfull test
+        [TestMethod]
+        public void DeleteAllUserGroupsWillNotFail()
+        {
+            var list = Connection.LoadAll<UserManagerUserGroup>();
+            Connection.SaveListDifferences(list.Where(l => l.Name == "default" || l.Name == "default-anonymous") /*list with "default" as expected => delete all others*/, list);
+        }
+        #endregion
+
+    }
+
+}

--- a/tik4net.tests/UserManagerTest.cs
+++ b/tik4net.tests/UserManagerTest.cs
@@ -10,39 +10,79 @@ namespace tik4net.tests
     public class UserManagerTest : TestBase
     {
         #region UserManagerUserGroups
+
         [TestMethod]
-        public void ListAllUserWillNotFail()
+        public void ListAllUserGroupsWillNotFail()
         {
-            var list = Connection.LoadAll<UserManagerUserGroup>().ToList();
+            var rnd = new Random();
+            string groupName = $"TEST{rnd.Next(999)}";
+            var userGroup = new UserManagerUserGroup()
+            {
+                Name = groupName
+            };
+            Connection.Save(userGroup);
+
+            var userGroups = Connection.LoadAll<UserManagerUserGroup>().ToList();
+            Assert.IsTrue(userGroups.Any(x => x.Name == groupName));
+
+            //Cleanup
+            Connection.Delete(userGroup);
         }
 
+        [TestMethod]
+        public void AddUserGroupWillNotFail()
+        {
+            var rnd = new Random();
+            string groupName = $"TEST{rnd.Next(999)}";
+            var userGroup = new UserManagerUserGroup()
+            {
+                Name = groupName
+            };
+            Connection.Save(userGroup);
 
-        #endregion
+            var userGroups = Connection.LoadAll<UserManagerUserGroup>().ToList();
+            Assert.IsTrue(userGroups.Any(x => x.Name == groupName));
+
+            //Cleanup
+            Connection.Delete(userGroup);
+        }
+
+        #endregion UserManagerUserGroups
 
         #region UserManagerUsers
+
         [TestMethod]
         public void AddSingleUserWillNotFail()
         {
             var rnd = new Random();
+            var randomUserName = $"TEST{rnd.Next(999)}";
             var user = new UserManagerUser()
             {
-                Name = $"TEST{rnd.Next(999)}",
+                Name = randomUserName,
                 Password = "secretpass",
                 Group = "default",
             };
 
             Connection.Save(user);
+
+
+            var users = Connection.LoadAll<UserManagerUser>().ToList();
+            Assert.IsTrue(users.FirstOrDefault(x => x.Name == randomUserName) != null);
+
+            //Cleanup
+            Connection.Delete(user);
         }
 
         [TestMethod]
         public void UpdateUserWillNotFail()
         {
             var rnd = new Random();
+            var randomUserName = $"TEST{rnd.Next(999)}";
 
             //Create user
             var user = new UserManagerUser()
             {
-                Name = $"TEST{rnd.Next(999)}",
+                Name = randomUserName,
                 Group = "default",
                 Password = "secretpass",
             };
@@ -52,6 +92,9 @@ namespace tik4net.tests
             user.Password = "changed";
             Connection.Save(user);
 
+            var users = Connection.LoadAll<UserManagerUser>().ToList();
+            Assert.IsTrue(users.FirstOrDefault(x => x.Name == randomUserName).Password == "changed");
+
             //Cleanup
             Connection.Delete(user);
         }
@@ -60,7 +103,11 @@ namespace tik4net.tests
         [TestMethod]
         public void DeleteAllUsersWillNotFail()
         {
-            var users = Connection.DeleteAll<UserManagerUser>();
+            _ = Connection.DeleteAll<UserManagerUser>();
+
+            var users = Connection.LoadAll<UserManagerUser>().Count();
+
+            Assert.IsTrue(users == 0);
         }
 
         [TestMethod]
@@ -82,6 +129,9 @@ namespace tik4net.tests
             };
             Connection.Save(user);
 
+            var testUser = Connection.LoadAll<UserManagerUser>().FirstOrDefault(x => x.Name == "User for " + groupName);
+            Assert.IsTrue(testUser != null && testUser.Group == groupName);
+
             //cleanup
             Connection.Delete(user);
             Connection.Delete(userGroup);
@@ -94,8 +144,439 @@ namespace tik4net.tests
             var list = Connection.LoadAll<UserManagerUserGroup>();
             Connection.SaveListDifferences(list.Where(l => l.Name == "default" || l.Name == "default-anonymous") /*list with "default" as expected => delete all others*/, list);
         }
-        #endregion
+
+        [TestMethod]
+        public void ListAllUsersWillReturnDefault()
+        {
+            var rnd = new Random();
+            var randomUserName = $"TEST{rnd.Next(999)}";
+            var user = new UserManagerUser()
+            {
+                Name = randomUserName,
+                Password = "secretpass",
+                Group = "default",
+            };
+
+            Connection.Save(user);
+
+            var users = Connection.LoadAll<UserManagerUser>().ToList();
+            Assert.IsTrue(users.FirstOrDefault(x => x.Name == randomUserName) != null);
+
+            //Cleanup
+            Connection.Delete(user);
+        }
+
+        #endregion UserManagerUsers
+
+        #region UserManagerProfiles
+
+        [TestMethod]
+        public void ListAllUserManagerProfilesWillNotFail()
+        {
+            var rnd = new Random();
+            string profileName = $"TEST{rnd.Next(999)}";
+            var profile = new UserManagerProfile()
+            {
+                Name = profileName
+            };
+            Connection.Save(profile);
+
+            var profiles = Connection.LoadAll<UserManagerProfile>().ToList();
+            Assert.IsTrue(profiles.Any(x => x.Name == profileName));
+
+            //Cleanup
+            Connection.Delete(profile);
+        }
+
+        [TestMethod]
+        public void AddUserManagerProfileWillNotFail()
+        {
+            var rnd = new Random();
+            string profileName = $"TEST{rnd.Next(999)}";
+            var profile = new UserManagerProfile()
+            {
+                Name = profileName
+            };
+            Connection.Save(profile);
+
+            var profiles = Connection.LoadAll<UserManagerProfile>().ToList();
+            Assert.IsTrue(profiles.Any(x => x.Name == profileName));
+
+            //Cleanup
+            Connection.Delete(profile);
+        }
+
+        [TestMethod]
+        public void UpdateUserManagerProfileWillNotFail()
+        {
+            var rnd = new Random();
+            string profileName = $"TEST{rnd.Next(999)}";
+            var profile = new UserManagerProfile()
+            {
+                Name = profileName,
+                Comment = "Initial comment",
+            };
+            Connection.Save(profile);
+
+            //Update
+            profile.Comment = "Changed Comment";
+            Connection.Save(profile);
+
+            var profiles = Connection.LoadAll<UserManagerProfile>().ToList();
+            Assert.IsTrue(profiles.FirstOrDefault(x => x.Name == profileName).Comment == "Changed Comment");
+
+            //Cleanup
+            Connection.Delete(profile);
+        }
+
+        [TestMethod]
+        public void DeleteUserManagerProfileWillNotFail()
+        {
+            var rnd = new Random();
+            string profileName = $"TEST{rnd.Next(999)}";
+            var profile = new UserManagerProfile()
+            {
+                Name = profileName
+            };
+            Connection.Save(profile);
+
+            // Delete
+            Connection.Delete(profile);
+
+            var profiles = Connection.LoadAll<UserManagerProfile>().ToList();
+            Assert.IsFalse(profiles.Any(x => x.Name == profileName));
+
+        }
+
+        #endregion UserManagerProfiles
+
+        #region UserManagerProfileLimitations
+
+        [TestMethod]
+        public void AddUserManagerProfileLimitationWillNotFail()
+        {
+            var rnd = new Random();
+            string limitationName = $"TEST{rnd.Next(999)}";
+            string profileName = $"TEST{rnd.Next(999)}";
+
+            var limitation = new UserManagerLimitation()
+            {
+                Name = limitationName,
+                Comment = "Limitation for profile limitation test",
+                RateLimitRx = "1M",
+                RateLimitTx = "512k"
+            };
+
+            Connection.Save(limitation);
+
+            var profile = new UserManagerProfile()
+            {
+                Name = profileName
+            };
+
+            Connection.Save(profile);
+
+            var profileLimitation = new UserManagerProfileLimitation()
+            {
+                Limitation = limitationName,
+                Profile = profileName
+            };
+
+            Connection.Save(profileLimitation);
+
+            var limitations = Connection.LoadAll<UserManagerProfileLimitation>().ToList();
+            Assert.IsTrue(limitations.Any(x => x.Limitation == limitationName && x.Profile == profileName));
+
+            //Cleanup
+            Connection.Delete(profileLimitation);
+            Connection.Delete(profile);
+            Connection.Delete(limitation);
+        }
+
+        [TestMethod]
+        public void UpdateUserManagerProfileLimitationWillNotFail()
+        {
+            var rnd = new Random();
+            string limitationName = $"TEST{rnd.Next(999)}";
+            string profileName = $"TEST{rnd.Next(999)}";
+
+            var limitation = new UserManagerLimitation()
+            {
+                Name = limitationName,
+                Comment = "Initial comment"
+            };
+            Connection.Save(limitation);
+
+            var profile = new UserManagerProfile()
+            {
+                Name = profileName
+            };
+
+            Connection.Save(profile);
+
+            var profileLimitation = new UserManagerProfileLimitation()
+            {
+                Limitation = limitationName,
+                Profile = profileName
+            };
+
+            Connection.Save(profileLimitation);
+
+
+            //Update
+            profileLimitation.Comment = "Changed Comment";
+            Connection.Save(profileLimitation);
+
+            var profileLimitations = Connection.LoadAll<UserManagerProfileLimitation>().ToList();
+            Assert.IsTrue(profileLimitations.FirstOrDefault(x => x.Limitation == limitationName && x.Profile == profileName).Comment == "Changed Comment");
+
+            //Cleanup
+            Connection.Delete(limitation);
+            Connection.Delete(profile);
+            Connection.Delete(profileLimitation);
+        }
+
+        [TestMethod]
+        public void DeleteUserManagerProfileLimitationWillNotFail()
+        {
+            var rnd = new Random();
+            string limitationName = $"TEST{rnd.Next(999)}";
+            string profileName = $"TEST{rnd.Next(999)}";
+
+            var limitation = new UserManagerLimitation()
+            {
+                Name = limitationName
+            };
+            Connection.Save(limitation);
+
+            var profile = new UserManagerProfile()
+            {
+                Name = profileName
+            };
+
+            Connection.Save(profile);
+
+            var profileLimitation = new UserManagerProfileLimitation()
+            {
+                Limitation = limitationName,
+                Profile = profileName
+            };
+
+            Connection.Save(profileLimitation);
+
+            // Delete
+            Connection.Delete(profileLimitation);
+
+            var limitations = Connection.LoadAll<UserManagerProfileLimitation>().ToList();
+            Assert.IsFalse(limitations.Any(x => x.Limitation == limitationName && x.Profile == profileName));
+
+            //Cleanup
+            Connection.Delete(limitation);
+            Connection.Delete(profile);
+        }
+
+        [TestMethod]
+        public void ListAllUserManagerProfileLimitationsWillNotFail()
+        {
+            var rnd = new Random();
+            string limitationName = $"TEST{rnd.Next(999)}";
+            string profileName = $"TEST{rnd.Next(999)}";
+
+            var limitation = new UserManagerLimitation()
+            {
+                Name = limitationName
+            };
+            Connection.Save(limitation);
+
+            var profile = new UserManagerProfile()
+            {
+                Name = profileName
+            };
+            Connection.Save(profile);
+
+            var profileLimitation = new UserManagerProfileLimitation()
+            {
+                Limitation = limitationName,
+                Profile = profileName
+            };
+            Connection.Save(profileLimitation);
+
+            var limitations = Connection.LoadAll<UserManagerProfileLimitation>().ToList();
+            Assert.IsTrue(limitations.Any(x => x.Limitation == limitationName && x.Profile == profileName));
+
+            //Cleanup
+            Connection.Delete(limitation);
+            Connection.Delete(profile);
+            Connection.Delete(profileLimitation);
+        }
+
+        #endregion UserManagerProfileLimitations
+
+        #region UserManagerUserProfiles
+
+        [TestMethod]
+        public void AddUserManagerUserProfileWillNotFail()
+        {
+            var rnd = new Random();
+            string profileName = $"TEST{rnd.Next(999)}";
+            string userName = $"TEST{rnd.Next(999)}";
+
+            var profile = new UserManagerProfile()
+            {
+                Name = profileName
+            };
+
+            Connection.Save(profile);
+
+            var user = new UserManagerUser()
+            {
+                Name = userName
+            };
+            Connection.Save(user);
+
+            var userProfile = new UserManagerUserProfile()
+            {
+                Profile = profileName,
+                User = userName
+            };
+            Connection.Save(userProfile);
+
+            var profiles = Connection.LoadAll<UserManagerUserProfile>().ToList();
+            Assert.IsTrue(profiles.Any(x => x.Profile == profileName));
+
+            //Cleanup
+            Connection.Delete(userProfile);
+            Connection.Delete(user);
+            Connection.Delete(profile);
+        }
+
+        [Ignore] //DAF: Feature not implemented in RouterOS?
+        [TestMethod]
+        public void UpdateUserManagerUserProfileWillNotFail()
+        {
+            var rnd = new Random();
+            string profileName = $"TEST{rnd.Next(999)}";
+            string userName = $"TEST{rnd.Next(999)}";
+
+            var user = new UserManagerUser()
+            {
+                Name = userName
+            };
+
+            Connection.Save(user);
+
+            var profile = new UserManagerProfile()
+            {
+                Name = profileName
+            };
+
+            Connection.Save(profile);
+
+            var userProfile = new UserManagerUserProfile()
+            {
+                Profile = profileName,
+                User = userName
+            };
+
+            Connection.Save(userProfile);
+
+            //Update
+            string userName2 = $"TEST{rnd.Next(999)}";
+
+            var user2 = new UserManagerUser()
+            {
+                Name = userName2
+            };
+
+            Connection.Save(user2);
+
+            userProfile.User = userName2;
+            Connection.Save(userProfile);
+
+            var profiles = Connection.LoadAll<UserManagerUserProfile>().ToList();
+            Assert.IsTrue(profiles.FirstOrDefault(x => x.Profile == profileName).User == userName2);
+
+            //Cleanup
+            Connection.Delete(userProfile);
+            Connection.Delete(user);
+            Connection.Delete(user2);
+            Connection.Delete(profile);
+
+        }
+
+        [TestMethod]
+        public void DeleteUserManagerUserProfileWillNotFail()
+        {
+            var rnd = new Random();
+            string profileName = $"TEST{rnd.Next(999)}";
+            string userName = $"TEST{rnd.Next(999)}";
+
+            var profile = new UserManagerProfile()
+            {
+                Name = profileName
+            };
+            Connection.Save(profile);
+
+            var user = new UserManagerUser()
+            {
+                Name = userName
+            };
+
+            Connection.Save(user);
+
+            var userProfile = new UserManagerUserProfile()
+            {
+                Profile = profileName,
+                User = userName
+            };
+            Connection.Save(userProfile);
+
+            // Delete
+            Connection.Delete(userProfile);
+
+            var profiles = Connection.LoadAll<UserManagerUserProfile>().ToList();
+            Assert.IsFalse(profiles.Any(x => x.Profile == profileName));
+        }
+
+        [TestMethod]
+        public void ListAllUserManagerUserProfilesWillNotFail()
+        {
+            var rnd = new Random();
+            string profileName = $"TEST{rnd.Next(999)}";
+            string userName = $"TEST{rnd.Next(999)}";
+
+            var profile = new UserManagerProfile()
+            {
+                Name = profileName
+            };
+
+            Connection.Save(profile);
+
+            var user = new UserManagerUser()
+            {
+                Name = userName
+            };
+
+            Connection.Save(user);
+
+            var userProfile = new UserManagerUserProfile()
+            {
+                Profile = profileName,
+                User = userName
+            };
+
+            Connection.Save(userProfile);
+
+            var profiles = Connection.LoadAll<UserManagerUserProfile>().ToList();
+            Assert.IsTrue(profiles.Any(x => x.Profile == profileName && x.User == userName));
+
+            //Cleanup
+            Connection.Delete(userProfile);
+        }
+
+        #endregion UserManagerUserProfiles
+
+
 
     }
-
 }

--- a/tik4net.tests/tik4net.tests.csproj
+++ b/tik4net.tests/tik4net.tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="IpHotspotActiveTest.cs" />
     <Compile Include="IpHotspotTest.cs" />
     <Compile Include="IpRouteTest.cs" />
+    <Compile Include="UserManagerTest.cs" />
     <Compile Include="MndpTests.cs" />
     <Compile Include="PppTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/tik4net/Api/ApiCommand.cs
+++ b/tik4net/Api/ApiCommand.cs
@@ -403,6 +403,8 @@ namespace tik4net.Api
                 EnsureReReponse(response.Take(response.Count() - 1).ToArray());   //!re  - reapeating 
                 EnsureDoneResponse(response.Last()); //!done
 
+                if (response.First() is ApiEmptySentence)
+                    return new List<ITikReSentence>();
                 return response.Take(response.Count() - 1).Cast<ITikReSentence>().ToList();
             }
             finally

--- a/tik4net/Api/ApiCommand.cs
+++ b/tik4net/Api/ApiCommand.cs
@@ -194,10 +194,10 @@ namespace tik4net.Api
 
         private ApiSentence EnsureSingleResponse(IEnumerable<ApiSentence> response)
         {
-            if (response.Count() != 1)
+            if (response.Count(x => !(x.Words.Count() == 1 && x.Words.ContainsKey(".section"))) != 1)
                 throw new TikCommandUnexpectedResponseException("Single response sentence expected.", this, response.Cast<ITikSentence>());
 
-            return response.Single();
+            return response.Last();
         }
 
         private void EnsureOneReAndDone(IEnumerable<ApiSentence> response)

--- a/tik4net/Api/ApiConnection.cs
+++ b/tik4net/Api/ApiConnection.cs
@@ -354,6 +354,7 @@ namespace tik4net.Api
                     case "!trap": return new ApiTrapSentence(sentenceWords);
                     case "!re": return new ApiReSentence(sentenceWords);
                     case "!fatal": return new ApiFatalSentence(sentenceWords);
+                    case "!empty": return new ApiEmptySentence();
                     case "": throw new IOException("Can not read sentence from connection"); // With SSL possibly not logged in  (SSL and new router with SSL_V2)
                     default: throw new NotImplementedException(string.Format("Response type '{0}' not supported", sentenceName));
                 }

--- a/tik4net/Api/ApiEmptySentence.cs
+++ b/tik4net/Api/ApiEmptySentence.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace tik4net.Api
+{
+    internal class ApiEmptySentence : ApiReSentence, ITikDoneSentence
+    {
+        public ApiEmptySentence() 
+            : base(Array.Empty<string>())
+        {
+        }
+
+        public string GetResponseWord()
+        {
+            return GetWordValue(TikSpecialProperties.Ret);
+        }
+
+        public string GetResponseWordOrDefault(string defaultValue)
+        {
+            return GetWordValueOrDefault(TikSpecialProperties.Ret, defaultValue);
+        }
+    }
+}

--- a/tik4net/Api/ApiSentence.cs
+++ b/tik4net/Api/ApiSentence.cs
@@ -22,7 +22,7 @@ namespace tik4net.Api
 
         public ApiSentence(IEnumerable<string> words)
         {
-            Regex keyValueRegex = new Regex("^=?(?<KEY>[^=]+)=(?<VALUE>.+)$", RegexOptions.Singleline);
+            Regex keyValueRegex = new Regex("^=?(?<KEY>[^=]+)=(?<VALUE>.*)$", RegexOptions.Singleline);
             foreach(string word in words)
             {
                 Match match = keyValueRegex.Match(word);

--- a/tik4net/tik4net.csproj
+++ b/tik4net/tik4net.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+	<OutputType>Library</OutputType>
+   </PropertyGroup>
    <PropertyGroup>
      <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
      <Description>Mikrotik API library</Description>
@@ -9,12 +12,15 @@
      <Copyright>Copyright (C) Daniel Frantik 2017</Copyright>
      <PackageTags>Mikrotik</PackageTags>
      <PackageOutputPath>../Build</PackageOutputPath>
-     <VersionPrefix>3.0.0</VersionPrefix>
+     <VersionPrefix>3.5.2</VersionPrefix>
      <VersionSuffix Condition=" '$(BUILD_BUILDNUMBER)' != '' ">CI-$(BUILD_BUILDNUMBER)</VersionSuffix>
      <VersionSuffix Condition=" '$(PREVIEW_NUMBER)' != '' ">pre-$(PREVIEW_NUMBER)</VersionSuffix>
      <AssemblyName>tik4net</AssemblyName>
      <RootNamespace>tik4net</RootNamespace>
+	 <ApplicationIcon />
+	 <OutputTypeEx>library</OutputTypeEx>
      <GenerateDocumentationFile>True</GenerateDocumentationFile>
+	 <StartupObject />
    </PropertyGroup>
    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
      <DefineConstants>TRACE;DEBUG</DefineConstants>


### PR DESCRIPTION
I have added the basic User Manager objects, and associtated tests to tiknet.objects.  This allows for the management is user related objects.

I have found this very useful for me, hopefully others will find it useful.  If I have more time in the future, and there is any interest, I will add the remaining User Manager objects.